### PR TITLE
Several small fixes

### DIFF
--- a/app/views_project.py
+++ b/app/views_project.py
@@ -89,7 +89,7 @@ def project(name):
         
         has_rodata_section = superpe.has_rodata_section()
         if has_rodata_section:
-            superpe.get_rdata_rangemanager().find_largest_gap()
+            data_sect_largest_gap_size = superpe.get_rdata_rangemanager().find_largest_gap()
         unresolved_dlls = pe.dllresolver.unresolved_dlls(superpe)
 
     project_dir = os.path.dirname(os.getcwd() + "\\" + project.settings.main_dir)

--- a/pe/superpe.py
+++ b/pe/superpe.py
@@ -241,13 +241,13 @@ class SuperPe():
 
     ## IAT
 
-    def get_vaddr_of_iatentry(self, func_name: str) -> int:
+    def get_vaddr_of_iatentry(self, func_name: str):
         iat = self.get_iat_entries()
         for dll_name in iat:
             for entry in iat[dll_name]:
                 if entry.func_name == func_name:
                     return entry.iat_vaddr
-        raise Exception(f"Function {func_name} not found in IAT")
+        return None
     
 
     def get_iat_entries(self) -> Dict[str, List[IatEntry]]:


### PR DESCRIPTION
## Description

2 small fixes:
- Modify `SuperPe.get_vaddr_of_iatentry` to return `None` instead of raising an exception.  
Throughout the codebase, every call to `get_vaddr_of_iatentry` checks if the returned value is None before proceeding. The current exception is not caught, causing the program to crash.
- Fix .rdata max gap size display on Web UI

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Error Trace (`get_vaddr_of_iatentry`)

- Payload: calc64.bin (272)
- Injectable: 7z.exe (557056)
- Add missing IAT entries: checked

```
C:\SuperMega>python web.py
Listen on: 0.0.0.0 5001
 * Serving Flask app 'web'
 * Debug mode: off
(project.py      ) --( Copy data/source/carrier/alloc_rw_rx/template.c to projects/test/
(helper.py       ) --( Remove old files
(config.py       ) -( Payload encryption keys: XOR: 33  XOR2: b'\xf2\x16'
(project.py      ) --( Copy data/source/carrier/alloc_rw_rx/template.c to projects/test/
(payload.py      ) --( Load payload: data/binary/shellcodes/calc64.bin
(supermega.py    ) --[ Config:  alloc_rw_rx  .text  xor_2  backdoor Entrypoint
(supermega.py    ) --[ Plugins: AntiEmulation=timeraw  Decoy=winexec  Guardrail=none
(templater.py    ) -( Create C from template: data/source/decoder/ -> projects/test/main.c
(templater.py    ) > AntiEmulation: iterations: 5  allocs: 100
(injectable.py   ) ---( Add datareuse: supermega_payload
(assembler.py    ) ---[ XOR2 payload with key b'\xf2\x16'
(compiler.py     ) -[ Compile C to ASM: projects/test/main.c -> projects/test/main.asm
(helper.py       )    > Run process: cl.exe /c /FA /GS- /Faprojects/test/ projects/test/main.c
(injectable.py   ) ---( Add datareuse: $SG72962
(injectable.py   ) ---( Add datareuse: $SG72990
Exception in thread Thread-34 (supermega_thread):
Traceback (most recent call last):
  File "C:\Program Files\Python313\Lib\threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "C:\Program Files\Python313\Lib\threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\SuperMega\app\views_project.py", line 232, in supermega_thread
    start(settings)
    ~~~~~^^^^^^^^^^
  File "C:\SuperMega\supermega.py", line 113, in start
    start_real(settings)
    ~~~~~~~~~~^^^^^^^^^^
  File "C:\SuperMega\supermega.py", line 198, in start_real
    functions = project.injectable.get_unresolved_iat()
  File "C:\SuperMega\model\injectable.py", line 72, in get_unresolved_iat
    if self.superpe.get_vaddr_of_iatentry(iat.name) == None:
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\SuperMega\pe\superpe.py", line 250, in get_vaddr_of_iatentry
    raise Exception(f"Function {func_name} not found in IAT")
Exception: Function WinExec not found in IAT
^C
```